### PR TITLE
Add MS365 certification file

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -61,7 +61,8 @@ html_show_sphinx = False
 html_copy_source = False
 html_extra_path = [
     'sitemap.xml',
-    'googlecd24172c95f0d5b3.html'
+    'googlecd24172c95f0d5b3.html',
+    'ms72214890.txt'
 ]
 
 html_theme_options = {

--- a/source/ms72214890.txt
+++ b/source/ms72214890.txt
@@ -1,0 +1,5 @@
+﻿{
+  "Description": "Web サイトのルートにある Microsoft 365 のドメイン所有権確認ファイル",
+  "Domain": "flexconfirmmail.com",
+  "Id": "a9abc63e-5008-41b2-a638-b57a28cf54e4"
+}


### PR DESCRIPTION
We need to add ms72214890.txt to the root path to prove `flexconfirmmail.com` is our domain.

## Test

* Build html locally with `make html`
  * [x] Confirm that ms72214890.txt is placed to the top directory of `build\html`